### PR TITLE
LogGrok doesn't lock files

### DIFF
--- a/LogGrokCore/DocumentViewModel.cs
+++ b/LogGrokCore/DocumentViewModel.cs
@@ -17,6 +17,7 @@ namespace LogGrokCore
         private bool _isCurrentDocument;
         private readonly LineProvider _lineProvider;
         private readonly TransformationPerformer _transformationPerformer;
+        private Stream _fileHolder;
 
         public DocumentViewModel(
             LineProvider lineProvider,
@@ -44,7 +45,8 @@ namespace LogGrokCore
             _transformationPerformer = transformationPerformer;
             _lineProvider = lineProvider;
             _markedLines.Changed += () => MarkedLinesChanged?.Invoke();
-            
+            _fileHolder = logModelFacade.LogFile.Open();
+
             CopyPathToClipboardCommand =
                 new DelegateCommand(() => TextCopy.ClipboardService.SetText(logFileFilePath));
             OpenContainingFolderCommand = new DelegateCommand(() => OpenContainingFolder(logFileFilePath));
@@ -106,6 +108,11 @@ namespace LogGrokCore
                 : $"/select, {Directory.GetParent(filePath)?.FullName}";
 
             _ = Process.Start("explorer.exe", cmdLine);
+        }
+
+        public void CloseFile()
+        {
+            _fileHolder.Dispose();
         }
     }
 }

--- a/LogGrokCore/MainWindow.xaml
+++ b/LogGrokCore/MainWindow.xaml
@@ -81,6 +81,7 @@
                                   avalonDockExtensions:BindingBehavior.CurrentDocument="{Binding CurrentDocument}"
                                   avalonDockExtensions:BindingBehavior.DocumentViewTemplate="{StaticResource DocumentTemplate}"
                                   avalonDockExtensions:BindingBehavior.DocumentsSource="{Binding Documents}"
+                                  avalonDockExtensions:BindingBehavior.OnDocumentCloseCommand="{Binding OnDocumentCloseCommand}"
                                   avalonDockExtensions:DocumentContextMenu.AdditionalContextMenuItems="{StaticResource AdditionalDocumentMenuItems}">
             <DockingManager.LayoutItemContainerStyle>
                 <Style TargetType="{x:Type LayoutItem}">

--- a/LogGrokCore/MainWindowViewModel.cs
+++ b/LogGrokCore/MainWindowViewModel.cs
@@ -26,7 +26,12 @@ namespace LogGrokCore
         public MarkedLinesViewModel MarkedLinesViewModel { get; }
         
         public ICommand OpenFileCommand => new DelegateCommand(OpenFile);
-        
+
+        public ICommand OnDocumentCloseCommand => DelegateCommand.Create((DocumentViewModel document) =>
+        {
+            document.CloseFile();
+        });
+
         public ICommand DropCommand => new DelegateCommand(
             obj=> OpenFiles((IEnumerable<string>)obj), 
             o => o is IEnumerable<string>);


### PR DESCRIPTION
Привет. 
LogGrok регулярно падает и пишет дампы. Начал разбирать дамп обратил внимание, что LogGrok не блокирует файлы при открытии, что приводит к проблемам.

Пример такой проблемы.
1) Открываем WinRar'ом RAR архив и не распаковывая его перетягиваем в LogGrok
3) WinRar распакует файл в временно хранилище в Temp
4) У WinRar'а есть интересная логика, при каждом запуске он мониторит наличии своих временных файлов в папке Temp и удаляет их, если с момента их создания прошло больше часа. [Подробнее про логику](https://www.win-rar.com/leave-artifacts-temp-folder.html?&L=0)
5) После того как WinRar удалил файл скролим файл в LogGrok 

LogGrok завершится с ошибкой. Падение происходит тут [при открытии FileStream](https://github.com/pekabon/LogGrokCore/blob/a574e6a8f60f0d3843adb1eb61f75d3ddfcc91f5/LogGrokCore.Data/LogFile.cs#L90) 

В качестве решения проблемы предлагаю держать на файле Stream, который будет блокировать удаление файла


