### PR TITLE
Add debug settings

### DIFF
--- a/LogGrokCore/ApplicationSettings.cs
+++ b/LogGrokCore/ApplicationSettings.cs
@@ -13,7 +13,9 @@ namespace LogGrokCore
         private static ApplicationSettings? instance;
 
         public static string SettingsFileName => PathHelpers.GetLocalFilePath("appsettings.yaml");
-        
+
+        public DebugSettings DebugSettings { get; set; } = new();
+
         public ColorSettings ColorSettings { get; private set; } = new();
 
         public ViewSettings ViewSettings { get; private set; } = new();
@@ -46,10 +48,10 @@ namespace LogGrokCore
                 .AddYamlFile(SettingsFileName, true, true);
 
             var settings = new ApplicationSettings();
-            
+
             var configuration = builder.Build();
             configuration.GetSection("Settings").Bind(settings);
-            
+
             ChangeToken.OnChange(() => configuration.GetReloadToken(), () =>
             {
                 var newSettings = new ApplicationSettings();
@@ -57,7 +59,7 @@ namespace LogGrokCore
                 settings.ColorSettings = newSettings.ColorSettings;
                 settings.LogFormats = newSettings.LogFormats;
             });
-            
+
             return settings;
         }
 

--- a/LogGrokCore/Bootstrap/EntryPoint.cs
+++ b/LogGrokCore/Bootstrap/EntryPoint.cs
@@ -105,7 +105,7 @@ namespace LogGrokCore.Bootstrap
             key.SetValue("DumpType", 2, RegistryValueKind.DWord);
         }
 
-        private static void StartElevatedInstanceWithParam(string type)
+        private static void StartElevatedInstanceWithParam(string argsToInstance)
         {
             var processPath = Environment.ProcessPath;
             if (processPath == null)
@@ -114,7 +114,7 @@ namespace LogGrokCore.Bootstrap
             var info = new ProcessStartInfo(processPath)
             {
                 UseShellExecute = true,
-                Arguments = type,
+                Arguments = argsToInstance,
                 Verb = "runas"
             };
 

--- a/LogGrokCore/Bootstrap/EntryPoint.cs
+++ b/LogGrokCore/Bootstrap/EntryPoint.cs
@@ -2,57 +2,110 @@
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Net.NetworkInformation;
+using DryIoc;
 using Microsoft.Win32;
+using Microsoft.Xaml.Behaviors.Media;
 
 namespace LogGrokCore.Bootstrap
 {
     static class EntryPoint
     {
-        private const string SetupWerOnly = "SetupWerOnly";
-        
+        private const string EnableWerOnly = "EnableWerOnly";
+        private const string DisableWerOnly = "DisableWerOnly";
+        private static string LogGrokErrorReportingKeyPath = $@"SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps\{Path.GetFileName(Environment.ProcessPath)}";
+
         [STAThread]
         public static void Main(string[] args)
         {
-            try
-            {
-                SetupWindowsErrorReporting();
-            }
-            catch (UnauthorizedAccessException)
-            {
-                if (args.FirstOrDefault() == SetupWerOnly)
-                    return;
+            var command = args.SingleOrDefault();
 
-                StartElevatedInstanceToSetupWer();
-            }
+            ConfigureErrorReporting(command);
 
-            if (args.SingleOrDefault() == SetupWerOnly)
+            if (IsNeedStopExecution(command))
                 return;
-            
+
             var fullPaths = args.Select(Path.GetFullPath).ToArray();
             var manager = new SingleInstanceManager();
             manager.Run(fullPaths);
         }
 
-        private static void SetupWindowsErrorReporting()
+        private static bool IsNeedStopExecution(string? command)
         {
-            var executableName = Path.GetFileName(Environment.ProcessPath);
-            var keyName = $@"SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps\{executableName}";
-            var existingKey = Registry.LocalMachine.OpenSubKey(keyName);
-            
-            if (existingKey != null)
-            {
-                return;
-            }
+            return command == EnableWerOnly || command == DisableWerOnly;
+        }
 
-            var key = Registry.LocalMachine.CreateSubKey(keyName);
+        private static void EvaluateIfNeed(Action func, string arguemntToEvaluatedProcess, string? currentCommand)
+        {
+            try
+            {
+                func();
+            }
+            catch (UnauthorizedAccessException)
+            {
+                if (IsNeedStopExecution(currentCommand))
+                    return;
+
+                StartElevatedInstanceWithParam(arguemntToEvaluatedProcess);
+            }
+        }
+
+        private static void ConfigureErrorReporting(string? command)
+        {
+            var isErrorReportingEnabled = IsErrorReportingEnabled();
+            var isCrashDumpsEnabled = ApplicationSettings.Instance().DebugSettings.EnableCrashDumps;
+            var isErrorReportingSettingsWasChanged = IsErrorReportingSettingsWasChanged();
+
+            var isNeedEnableWer = (isCrashDumpsEnabled && !isErrorReportingEnabled) || command == EnableWerOnly || isErrorReportingSettingsWasChanged;
+            var isNeedDisableWer = (!isCrashDumpsEnabled && isErrorReportingEnabled) || command == DisableWerOnly;
+
+            if (isNeedEnableWer)
+            {
+                EvaluateIfNeed(EnableErrorReporting, EnableWerOnly, command);
+            }
+            else if (isNeedDisableWer)
+            {
+                EvaluateIfNeed(DisableErrorReporting, DisableWerOnly, command);
+            }
+        }
+
+        private static bool IsErrorReportingSettingsWasChanged()
+        {
+            var key = Registry.LocalMachine.OpenSubKey(LogGrokErrorReportingKeyPath);
+
+            if (key == null) 
+                return false;
+
+            var maxDumpsCount = ApplicationSettings.Instance().DebugSettings.MaxDumpsCount;
+
+            return (int)key.GetValue("DumpCount", -1) != maxDumpsCount;
+        }
+
+        private static bool IsErrorReportingEnabled()
+        {
+            var key = Registry.LocalMachine.OpenSubKey(LogGrokErrorReportingKeyPath);
+            return key != null;
+        }
+
+        private static void DisableErrorReporting()
+        {
+            Registry.LocalMachine.DeleteSubKey(LogGrokErrorReportingKeyPath);
+        }
+
+        private static void EnableErrorReporting()
+        {
+
+            var key = Registry.LocalMachine.CreateSubKey(LogGrokErrorReportingKeyPath);
             key.SetValue("DumpFolder",
                 HomeDirectoryPathProvider.GetDirectoryFullPath("Dumps"),
                 RegistryValueKind.ExpandString);
-            key.SetValue("DumpCount", 10, RegistryValueKind.DWord);
+
+            var maxDumpsCount = ApplicationSettings.Instance().DebugSettings.MaxDumpsCount;
+            key.SetValue("DumpCount", maxDumpsCount, RegistryValueKind.DWord);
             key.SetValue("DumpType", 2, RegistryValueKind.DWord);
         }
-        
-        private static void StartElevatedInstanceToSetupWer()
+
+        private static void StartElevatedInstanceWithParam(string type)
         {
             var processPath = Environment.ProcessPath;
             if (processPath == null)
@@ -61,7 +114,7 @@ namespace LogGrokCore.Bootstrap
             var info = new ProcessStartInfo(processPath)
             {
                 UseShellExecute = true,
-                Arguments = SetupWerOnly,
+                Arguments = type,
                 Verb = "runas"
             };
 

--- a/LogGrokCore/DebugSettings.cs
+++ b/LogGrokCore/DebugSettings.cs
@@ -1,0 +1,8 @@
+﻿namespace LogGrokCore
+{
+    public class DebugSettings
+    {
+        public bool EnableCrashDumps { get; set; } = false;
+        public int MaxDumpsCount { get; set; } = 10;
+    }
+}

--- a/LogGrokCore/appsettings.yaml
+++ b/LogGrokCore/appsettings.yaml
@@ -1,5 +1,9 @@
 Settings:
-  EnableCrashDumps: true
+  DebugSettings:
+    # Restart required after changing debug settings
+    EnableCrashDumps: false
+    MaxDumpsCount: 10
+
   ColorSettings:
     # Find list of supported values for Color here https://docs.microsoft.com/ru-ru/dotnet/api/system.drawing.color?view=net-6.0
     # or use "#AARRGGBB" notation

--- a/LogGrokCore/appsettings.yaml
+++ b/LogGrokCore/appsettings.yaml
@@ -1,4 +1,5 @@
 Settings:
+  EnableCrashDumps: true
   ColorSettings:
     # Find list of supported values for Color here https://docs.microsoft.com/ru-ru/dotnet/api/system.drawing.color?view=net-6.0
     # or use "#AARRGGBB" notation


### PR DESCRIPTION
Привет. 
LogGrok пишет дампы и это здорово. Но есть проблемы:
1) Довольно критичная: LogGrok записывает дампы без уведомления и что самое печальное, в не самое очевидное место. У меня какое-то время был системный SSD на 250Гб. В какой-то момент мне стало не хватать памяти и я начал разбираться куда она делась. Я довольно сильно удивился, когда обнаружил, что LogGrok записал дампов на 30Гб в папку локального администратора.

2) Некритичная: LogGrok запрашивает права администратора при включении записи отладочных дампов. К сожалению, не всегда на устройстве есть доступ к учетной записи с правами администратора. Здорово то, что LogGrok продолжает работать, даже если ему не предоставить эти права, но постоянный UAC с запросом прав администратора немного раздражает.

В этом PR:
- Добавил настройки для включения/выключения записи отладочных дампов в appsettings.yaml
- По умолчанию запись дампов выключена
- Если пользователь не включает запись дампов UAC не появляется
- Настройка, через которую можно регулировать максимальное количество дампов, на случай если снимать дампы захочется, а памяти на компьютере не очень много

Возможно стоит добавить кастомизацию пути для записи дампов.