### PR TITLE
Fix Crash

### DIFF
--- a/LogGrokCore/Controls/TextRender/GlyphLine.cs
+++ b/LogGrokCore/Controls/TextRender/GlyphLine.cs
@@ -37,9 +37,9 @@ public class GlyphLine : IDisposable
             if (!(relativeHorizontalPosition <= currentOffset)) continue;
             if (relativeHorizontalPosition + currentCharWidth / 2.0 < currentOffset)
                 return i;
-            return i + 1;
+            return i < _advanceWidthForChar.Count - 1 ? i + 1 : i;
         }
-        return _advanceWidthForChar.Count;
+        return _advanceWidthForChar.Count - 1;
     }
 
     public Rect GetTextBounds(Point startPoint, int firstTextSourceCharacterIndex, int textLength)

--- a/LogGrokCore/Controls/TextRender/GlyphLine.cs
+++ b/LogGrokCore/Controls/TextRender/GlyphLine.cs
@@ -37,9 +37,9 @@ public class GlyphLine : IDisposable
             if (!(relativeHorizontalPosition <= currentOffset)) continue;
             if (relativeHorizontalPosition + currentCharWidth / 2.0 < currentOffset)
                 return i;
-            return i < _advanceWidthForChar.Count - 1 ? i + 1 : i;
+            return i + 1;
         }
-        return _advanceWidthForChar.Count - 1;
+        return _advanceWidthForChar.Count;
     }
 
     public Rect GetTextBounds(Point startPoint, int firstTextSourceCharacterIndex, int textLength)

--- a/LogGrokCore/Controls/TextRender/TextControl.cs
+++ b/LogGrokCore/Controls/TextRender/TextControl.cs
@@ -323,6 +323,9 @@ public class TextControl : Control
             left--;
         }
 
+        if (position >= span.Length)
+            return (left, span.Length - left);
+
         var right = position;
         while (right < span.Length - 1 && IsWordPart(span[right + 1]))
         {


### PR DESCRIPTION
Привет. 
Нашел еще одну причину падения
1. Выделяем полностью строку. 
2. Введем мышкой по строке вправо до тех пор пока не найдем место где каретка превращается в обычный указатель мыши.
3. Возвращаемся назад пока указатель не станет кареткой
4. Дважды кликаем

Приблизительно в место указанным красным на скриншоте.
![image](https://github.com/user-attachments/assets/ac789a5a-4fd2-4737-a1e2-5e8fe6e03641)

Если я правильно понял когда мы выделяем строку это увеличивает размер TextView и позволяет получить позицию из функции [GetTextPosition](https://github.com/pekabon/LogGrokCore/blob/48fa612139f50a7b7f0f11284c8d4c3cbd675b26/LogGrokCore/Controls/TextRender/TextControl.cs#L306) указывающую за последний символ текста. 
Далее полученная позиция обрабатывается в [GetWordSelectionRange](https://github.com/pekabon/LogGrokCore/blob/48fa612139f50a7b7f0f11284c8d4c3cbd675b26/LogGrokCore/Controls/TextRender/TextControl.cs#L308) где из позиции получают границы слова, но функция не учитывает то, что позиция может указывать за конец строки и возвращает некорректный размер
В результате в метод [Slice](https://github.com/pekabon/LogGrokCore/blob/48fa612139f50a7b7f0f11284c8d4c3cbd675b26/LogGrokCore/Controls/TextRender/TextControl.cs#L311) передается размер превышающий размер исходной строки из-за чего летит исключение, которое никто не перехватывает 